### PR TITLE
Fix readMaxScore() so it does not always return zero

### DIFF
--- a/Game23/modules/Game2048.py
+++ b/Game23/modules/Game2048.py
@@ -122,7 +122,7 @@ class Game2048(object):
 	'''读取游戏最高分'''
 	def readMaxScore(self):
 		try:
-			f = open(filepath, 'r', encoding='utf-8')
+			f = open(self.max_score_filepath, 'r', encoding='utf-8')
 			score = int(f.read().strip())
 			f.close()
 			return score


### PR DESCRIPTION
`readMaxScore()` currently refers to an ___undefined name___ filepath which raises NameError which is caught by the [bare exception](https://realpython.com/the-most-diabolical-python-antipattern) which ___always___ returns zero.